### PR TITLE
Feature: similar items selected with multi-select sell as bulk on flea

### DIFF
--- a/Patches/CatchAddOfferClickPatch.cs
+++ b/Patches/CatchAddOfferClickPatch.cs
@@ -43,15 +43,16 @@ namespace FastSellInFlea.Patches
                     var maxOffersCountNow = FastSellInFleaPlugin.Session.RagFair.MaxOffersCount;
                     int offersAdded = 0;
                     int offerLimit = maxOffersCountNow - myOffersCountNow;
-                    
-                    foreach (var selectedItem in MultiSelect.Items)
+                    var itemsGrouped = FastSellInFleaPlugin.GroupSimilarItems(MultiSelect.Items);
+
+                    foreach (var selectedItem in itemsGrouped)
                     {
                         if (offersAdded >= offerLimit)
                             break;
                         
-                        if (FastSellInFleaPlugin.CanBeSelectedAtRagfair(selectedItem))
+                        if (FastSellInFleaPlugin.CanBeSelectedAtRagfair(selectedItem[0]))
                         {
-                            FastSellInFleaPlugin.TryGetPrice(selectedItem, price =>
+                            FastSellInFleaPlugin.TryGetPrice(selectedItem[0], price =>
                             {
                                 if (price <= 0 || offersAdded >= offerLimit)
                                     return;


### PR DESCRIPTION
Multi-select wasn't working as expected - it was still making separate offers for each item you selected, which was ruining the purpose of it. Fixed it so similar items(type, condition etc.) now get bundled together into proper bulk offers.
Before:
<img width="1907" height="614" alt="fleaBefore-min" src="https://github.com/user-attachments/assets/d89c2a99-dcbf-4295-8ac8-dfa0342a9527" />
After:
<img width="1881" height="431" alt="fleaAfter-min" src="https://github.com/user-attachments/assets/ce47639e-bfc7-4100-9832-6053ef3339f5" />
